### PR TITLE
Intersect bug

### DIFF
--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -45,19 +45,22 @@ DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
   auto ng_x = x.ngroups() ;
   auto ng_y = y.ngroups() ;
   
+  CharacterVector chrom_x = data_x["chrom"];
+  CharacterVector chrom_y = data_y["chrom"];
+  
   GroupedDataFrame::group_iterator git_x = x.group_begin() ;
   for( int nx=0; nx<ng_x; nx++, ++git_x){
     
     SlicingIndex gi_x = *git_x ;
-    auto group_x = gi_x.group() ;
+    int group_x = gi_x[0];
     
     GroupedDataFrame::group_iterator git_y = y.group_begin() ;
     for( int ny=0; ny<ng_y; ny++, ++git_y) {
       
       SlicingIndex gi_y = *git_y ;
-      auto group_y = gi_y.group() ;
-      
-      if( group_x == group_y ) {
+      int group_y = gi_y[0];
+
+      if( chrom_x[group_x] == chrom_y[group_y] ) {
         
         intervalVector vx = makeIntervalVector(data_x, gi_x) ;
         intervalVector vy = makeIntervalVector(data_y, gi_y) ;

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -152,7 +152,7 @@ test_that("`strand_opp` results are processed correctly", {
   expect_false(res$strand.x == res$strand.y)
 })
 
-test_that("intersections from x bed table with more chroms than y are captured", {
+test_that("intersections from x bed_tbl with more chroms than y are captured", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end,
     "chr1",    100,       200,
@@ -167,7 +167,7 @@ test_that("intersections from x bed table with more chroms than y are captured",
   expect_true("chr3" %in% res$chrom)
 })
 
-test_that("intersections from y bed table with more chroms are captured", {
+test_that("intersections from y bed_tbl with more chroms are captured", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end,
     "chr3",    400,       500

--- a/tests/testthat/test_intersect.r
+++ b/tests/testthat/test_intersect.r
@@ -151,3 +151,33 @@ test_that("`strand_opp` results are processed correctly", {
   
   expect_false(res$strand.x == res$strand.y)
 })
+
+test_that("intersections from x bed table with more chroms than y are captured", {
+  x <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr1",    100,       200,
+    "chr3",    400,       500
+  )
+  
+  y <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr3",    425,       475) 
+  
+  res <- bed_intersect(x, y)
+  expect_true("chr3" %in% res$chrom)
+})
+
+test_that("intersections from y bed table with more chroms are captured", {
+  x <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr3",    400,       500
+  )
+  
+  y <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr1",    100,       200,
+    "chr3",    425,       475) 
+  
+  res <- bed_intersect(x, y)
+  expect_true("chr3" %in% res$chrom)
+})


### PR DESCRIPTION
The `group()` function from `dplyr::SlicingIndex` reports the group index rather than the value of the group.  For intersections where the number of chromosomes are different, this throws off the index numbers, resulting in lost intersections. Issue #44 

