### PR TITLE
Intersect module

### DIFF
--- a/inst/include/valr.h
+++ b/inst/include/valr.h
@@ -22,7 +22,7 @@ extern intervalVector makeIntervalVector(DataFrame df, SlicingIndex si) ;
 // interval vectors and apply a function to each interval vector
 
 template < typename FN, typename... ARGS >
-void chromLoop( const GroupedDataFrame& x, 
+void PairedGroupApply( const GroupedDataFrame& x, 
                 const GroupedDataFrame& y,
                 FN&& fn, ARGS&&... args ){
   

--- a/inst/include/valr.h
+++ b/inst/include/valr.h
@@ -4,6 +4,7 @@
 #include <Rcpp.h>
 #include <dplyr.h>
 #include "IntervalTree.h"
+#include <functional>
 //[[Rcpp::depends(dplyr)]]
 //[[Rcpp::plugins(cpp11)]]
 
@@ -17,6 +18,46 @@ typedef IntervalTree<int>            intervalTree ;
 extern int intervalOverlap(const interval_t& a, const interval_t& b) ;
 extern intervalVector makeIntervalVector(DataFrame df, SlicingIndex si) ;
 
+// template function to generate matched chromosome
+// interval vectors and apply a function to each interval vector
+
+template < typename FN, typename... ARGS >
+void chromLoop( const GroupedDataFrame& x, 
+                const GroupedDataFrame& y,
+                FN&& fn, ARGS&&... args ){
+  
+  auto data_x = x.data() ;
+  auto data_y = y.data() ;
+
+  auto ng_x = x.ngroups() ;
+  auto ng_y = y.ngroups() ;
+
+  CharacterVector chrom_x = data_x["chrom"];
+  CharacterVector chrom_y = data_y["chrom"];
+  
+    
+  GroupedDataFrame::group_iterator git_x = x.group_begin() ;
+  for( int nx=0; nx<ng_x; nx++, ++git_x){
+  
+    SlicingIndex gi_x = *git_x ;
+    int group_x = gi_x[0];
+  
+    GroupedDataFrame::group_iterator git_y = y.group_begin() ;
+    for( int ny=0; ny<ng_y; ny++, ++git_y) {
+    
+      SlicingIndex gi_y = *git_y ;
+      int group_y = gi_y[0];
+    
+      if( chrom_x[group_x] == chrom_y[group_y] ) {
+      
+        intervalVector vx = makeIntervalVector(data_x, gi_x) ;
+        intervalVector vy = makeIntervalVector(data_y, gi_y) ;
+      
+        std::bind( std::forward<FN>(fn), vx, vy, std::forward<ARGS>(args)... )();
+      }
+    } 
+  }
+}
 // boost icl
 #include <boost/icl/interval_set.hpp>
 #include <boost/icl/discrete_interval.hpp>

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -79,14 +79,14 @@ void closest_grouped(intervalVector& vx, intervalVector& vy,
 DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
                        const std::string& suffix_x, const std::string& suffix_y) {
 
-  auto ng_x = x.ngroups() ;
-  auto ng_y = y.ngroups() ;
+//  auto ng_x = x.ngroups() ;
+//  auto ng_y = y.ngroups() ;
 
   DataFrame df_x = x.data() ;
   DataFrame df_y = y.data() ;
   
-  auto nr_x = df_x.nrows() ;
-  auto nr_y = df_y.nrows() ;
+//  auto nr_x = df_x.nrows() ;
+//  auto nr_y = df_y.nrows() ;
  
   // for subsetting / return df
   std::vector<int> indices_x ;
@@ -94,28 +94,9 @@ DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
   std::vector<int> overlap_sizes ;
   std::vector<int> distance_sizes ;
   
-  // XXX this shoudld be refactored as a reusable function, used in intersect,
-  // subtract, here, possibely more
-  GroupedDataFrame::group_iterator git_x = x.group_begin() ;
-  for( int nx=0; nx<ng_x; nx++, ++git_x) {
-    
-    SlicingIndex si_x = *git_x ;
-    auto label_x = si_x.group() ;
-    
-    GroupedDataFrame::group_iterator git_y = y.group_begin() ;
-    for (int ny=0; ny<ng_y; ny++, ++git_y) {
-      
-      SlicingIndex si_y = *git_y ;
-      auto label_y = si_y.group() ;
-     
-      if (label_x == label_y) {
-        intervalVector vx = makeIntervalVector(df_x, si_x) ;
-        intervalVector vy = makeIntervalVector(df_y, si_y) ;
-        
-        closest_grouped(vx, vy, indices_x, indices_y, overlap_sizes, distance_sizes) ;
-      } 
-    }
-  }
+  // set up interval trees for each chromosome and apply closest_grouped
+  chromLoop(x, y, closest_grouped, std::ref(indices_x), std::ref(indices_y), 
+            std::ref(overlap_sizes), std::ref(distance_sizes)); 
   
   DataFrame subset_x = DataFrameSubsetVisitors(df_x, names(df_x)).subset(indices_x, "data.frame");
   DataFrame subset_y = DataFrameSubsetVisitors(df_y, names(df_y)).subset(indices_y, "data.frame");

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -95,7 +95,7 @@ DataFrame closest_impl(GroupedDataFrame x, GroupedDataFrame y,
   std::vector<int> distance_sizes ;
   
   // set up interval trees for each chromosome and apply closest_grouped
-  chromLoop(x, y, closest_grouped, std::ref(indices_x), std::ref(indices_y), 
+  PairedGroupApply(x, y, closest_grouped, std::ref(indices_x), std::ref(indices_y), 
             std::ref(overlap_sizes), std::ref(distance_sizes)); 
   
   DataFrame subset_x = DataFrameSubsetVisitors(df_x, names(df_x)).subset(indices_x, "data.frame");

--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -42,7 +42,7 @@ DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
   auto data_y = y.data() ;
 
   // set up interval trees for each chromosome and apply intersect_group
-  chromLoop(x, y, intersect_group, std::ref(indices_x), std::ref(indices_y), std::ref(overlap_sizes)); 
+  PairedGroupApply(x, y, intersect_group, std::ref(indices_x), std::ref(indices_y), std::ref(overlap_sizes)); 
   
   DataFrame subset_x = DataFrameSubsetVisitors(data_x, names(data_x)).subset(indices_x, "data.frame");
   DataFrame subset_y = DataFrameSubsetVisitors(data_y, names(data_y)).subset(indices_y, "data.frame");

--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -3,7 +3,6 @@
 void intersect_group(intervalVector vx, intervalVector vy,
                      std::vector<int>& indices_x, std::vector<int>& indices_y,
                      std::vector<int>& overlap_sizes) {
-  
   intervalTree tree_y(vy) ;
   intervalVector overlaps ;
 
@@ -18,13 +17,17 @@ void intersect_group(intervalVector vx, intervalVector vy,
       
       int overlap_size = intervalOverlap(*it, *oit) ;
       overlap_sizes.push_back(overlap_size) ;
-      
+
       indices_x.push_back(it->value) ;
       indices_y.push_back(oit->value) ;
     }
-    
+
     overlaps.clear() ;
-  } 
+  }
+//  int n = 10;
+//  for(int i=0; i < n; i++){
+//    Rcout << vx[i] <<"\t" << vy[i] << "\t" << overlap_sizes[i] << "\t" << indices_x[i] << "\t" << indices_y[i] << "\n";
+//  }
 }
 
 
@@ -41,34 +44,11 @@ DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
   
   auto data_x = x.data() ;
   auto data_y = y.data() ;
-  
-  auto ng_x = x.ngroups() ;
-  auto ng_y = y.ngroups() ;
-  
-  CharacterVector chrom_x = data_x["chrom"];
-  CharacterVector chrom_y = data_y["chrom"];
-  
-  GroupedDataFrame::group_iterator git_x = x.group_begin() ;
-  for( int nx=0; nx<ng_x; nx++, ++git_x){
-    
-    SlicingIndex gi_x = *git_x ;
-    int group_x = gi_x[0];
-    
-    GroupedDataFrame::group_iterator git_y = y.group_begin() ;
-    for( int ny=0; ny<ng_y; ny++, ++git_y) {
-      
-      SlicingIndex gi_y = *git_y ;
-      int group_y = gi_y[0];
 
-      if( chrom_x[group_x] == chrom_y[group_y] ) {
-        
-        intervalVector vx = makeIntervalVector(data_x, gi_x) ;
-        intervalVector vy = makeIntervalVector(data_y, gi_y) ;
-       
-        intersect_group(vx, vy, indices_x, indices_y, overlap_sizes) ; 
-      }
-    } 
-  }
+  // set up interval trees for each chromosome and apply intersect_group
+  chromLoop(x, y, intersect_group, std::ref(indices_x), std::ref(indices_y), std::ref(overlap_sizes)); 
+//  overlap_sizes[0] = 1;
+
   
   DataFrame subset_x = DataFrameSubsetVisitors(data_x, names(data_x)).subset(indices_x, "data.frame");
   DataFrame subset_y = DataFrameSubsetVisitors(data_y, names(data_y)).subset(indices_y, "data.frame");

--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -24,10 +24,6 @@ void intersect_group(intervalVector vx, intervalVector vy,
 
     overlaps.clear() ;
   }
-//  int n = 10;
-//  for(int i=0; i < n; i++){
-//    Rcout << vx[i] <<"\t" << vy[i] << "\t" << overlap_sizes[i] << "\t" << indices_x[i] << "\t" << indices_y[i] << "\n";
-//  }
 }
 
 
@@ -47,8 +43,6 @@ DataFrame intersect_impl(GroupedDataFrame x, GroupedDataFrame y,
 
   // set up interval trees for each chromosome and apply intersect_group
   chromLoop(x, y, intersect_group, std::ref(indices_x), std::ref(indices_y), std::ref(overlap_sizes)); 
-//  overlap_sizes[0] = 1;
-
   
   DataFrame subset_x = DataFrameSubsetVisitors(data_x, names(data_x)).subset(indices_x, "data.frame");
   DataFrame subset_y = DataFrameSubsetVisitors(data_y, names(data_y)).subset(indices_y, "data.frame");

--- a/src/substract.cpp
+++ b/src/substract.cpp
@@ -23,7 +23,7 @@ DataFrame subtract_impl(GroupedDataFrame gdf_x, GroupedDataFrame gdf_y) {
     SlicingIndex indices_x = *git_x ; 
     std::string chrom_x = as<std::string>(chroms_x[indices_x[0]]);
     // keep track of if x chrom is present in y
-    bool s_chrom_x_seen(false);
+    bool chrom_x_seen(false);
     
     GroupedDataFrame::group_iterator git_y = gdf_y.group_begin() ;
     for(int ny=0; ny<ng_y; ny++, ++git_y) {
@@ -32,7 +32,7 @@ DataFrame subtract_impl(GroupedDataFrame gdf_x, GroupedDataFrame gdf_y) {
       std::string chrom_y = as<std::string>(chroms_y[indices_y[0]]);
       
       if( chrom_x == chrom_y ) {
-        s_chrom_x_seen = true ;
+        chrom_x_seen = true ;
   	    icl_interval_set_t interval_set_x = makeIclIntervalSet(df_x, indices_x) ; 
   	    icl_interval_set_t interval_set_y = makeIclIntervalSet(df_y, indices_y) ;
   	  
@@ -52,7 +52,7 @@ DataFrame subtract_impl(GroupedDataFrame gdf_x, GroupedDataFrame gdf_y) {
       }
     }
     // return x intervals if x chromosome not found in y
-    if (s_chrom_x_seen) {
+    if (chrom_x_seen) {
       continue;
       }
     else {

--- a/src/substract.cpp
+++ b/src/substract.cpp
@@ -13,22 +13,23 @@ DataFrame subtract_impl(GroupedDataFrame gdf_x, GroupedDataFrame gdf_y) {
   DataFrame df_x = gdf_x.data() ;
   DataFrame df_y = gdf_y.data() ; 
   
-  CharacterVector chroms = df_x["chrom"] ;
+  CharacterVector chroms_x = df_x["chrom"] ;
+  CharacterVector chroms_y = df_y["chrom"] ;
   
   GroupedDataFrame::group_iterator git_x = gdf_x.group_begin() ;
   
   for(int nx=0; nx<ng_x; nx++, ++git_x) {
     
     SlicingIndex indices_x = *git_x ; 
-    auto group_x = indices_x.group() ;
+    std::string chrom_x = as<std::string>(chroms_x[indices_x[0]]);
     
     GroupedDataFrame::group_iterator git_y = gdf_y.group_begin() ;
     for(int ny=0; ny<ng_y; ny++, ++git_y) {
   
       SlicingIndex indices_y = *git_y ; 
-      auto group_y = indices_y.group() ;
+      std::string chrom_y = as<std::string>(chroms_y[indices_y[0]]);
       
-      if ( group_x == group_y ) {
+      if( chrom_x == chrom_y ) {
 
   	    icl_interval_set_t interval_set_x = makeIclIntervalSet(df_x, indices_x) ; 
   	    icl_interval_set_t interval_set_y = makeIclIntervalSet(df_y, indices_y) ;
@@ -41,12 +42,12 @@ DataFrame subtract_impl(GroupedDataFrame gdf_x, GroupedDataFrame gdf_y) {
   	    // get chrom name based on first index in indices_x
   	    // XXX it would be a lot nicer to fectch this from the current data 
   	    // in indices_y via symbol or label but that doesn't seem to work.
-  	    std::string chrom = as<std::string>(chroms[indices_x[0]]) ;
+
   	    
         icl_interval_set_t::iterator it ;
         for( it = interval_sub.begin(); it != interval_sub.end(); ++it) {
           
-          chrom_out.push_back(chrom) ;
+          chrom_out.push_back(chrom_x) ;
           starts_out.push_back(it->lower()) ;
           ends_out.push_back(it->upper()) ;
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,6 @@
 #include "valr.h"
 
+
 int intervalOverlap(const interval_t& a, const interval_t& b) {
   return(std::min(a.stop, b.stop) - std::max(a.start, b.start)) ;    
 }
@@ -41,3 +42,41 @@ icl_interval_set_t makeIclIntervalSet(DataFrame df, SlicingIndex indices) {
   return iset ;
 }
  
+ // generic function to loop through x and y bed_tbls and apply a function to each matched chromosomes
+ 
+// void chromLoop( const GroupedDataFrame& x, const GroupedDataFrame& y,
+//                std::function<void (intervalVector&, intervalVector&)> fxn) {
+
+//   auto data_x = x.data() ;
+//   auto data_y = y.data() ;
+   
+   //   auto ng_x = x.ngroups() ;
+   //   auto ng_y = y.ngroups() ;
+   
+   //CharacterVector chrom_x = data_x["chrom"];
+   //CharacterVector chrom_y = data_y["chrom"];
+   
+   
+   //   GroupedDataFrame::group_iterator git_x = x.group_begin() ;
+   // for( int nx=0; nx<ng_x; nx++, ++git_x){
+     
+     // SlicingIndex gi_x = *git_x ;
+     //   int group_x = gi_x[0];
+     
+     // GroupedDataFrame::group_iterator git_y = y.group_begin() ;
+     //     for( int ny=0; ny<ng_y; ny++, ++git_y) {
+       
+       //SlicingIndex gi_y = *git_y ;
+       // int group_y = gi_y[0];
+       
+       // if( chrom_x[group_x] == chrom_y[group_y] ) {
+         
+         //intervalVector vx = makeIntervalVector(data_x, gi_x) ;
+         // intervalVector vy = makeIntervalVector(data_y, gi_y) ;
+         
+         //fxn(vx, vy ) ; 
+         //}
+       //} 
+     //}
+   // }
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -41,42 +41,4 @@ icl_interval_set_t makeIclIntervalSet(DataFrame df, SlicingIndex indices) {
 
   return iset ;
 }
- 
- // generic function to loop through x and y bed_tbls and apply a function to each matched chromosomes
- 
-// void chromLoop( const GroupedDataFrame& x, const GroupedDataFrame& y,
-//                std::function<void (intervalVector&, intervalVector&)> fxn) {
-
-//   auto data_x = x.data() ;
-//   auto data_y = y.data() ;
-   
-   //   auto ng_x = x.ngroups() ;
-   //   auto ng_y = y.ngroups() ;
-   
-   //CharacterVector chrom_x = data_x["chrom"];
-   //CharacterVector chrom_y = data_y["chrom"];
-   
-   
-   //   GroupedDataFrame::group_iterator git_x = x.group_begin() ;
-   // for( int nx=0; nx<ng_x; nx++, ++git_x){
-     
-     // SlicingIndex gi_x = *git_x ;
-     //   int group_x = gi_x[0];
-     
-     // GroupedDataFrame::group_iterator git_y = y.group_begin() ;
-     //     for( int ny=0; ny<ng_y; ny++, ++git_y) {
-       
-       //SlicingIndex gi_y = *git_y ;
-       // int group_y = gi_y[0];
-       
-       // if( chrom_x[group_x] == chrom_y[group_y] ) {
-         
-         //intervalVector vx = makeIntervalVector(data_x, gi_x) ;
-         // intervalVector vy = makeIntervalVector(data_y, gi_y) ;
-         
-         //fxn(vx, vy ) ; 
-         //}
-       //} 
-     //}
-   // }
 

--- a/tests/testthat/test_subtract.r
+++ b/tests/testthat/test_subtract.r
@@ -72,3 +72,32 @@ test_that("fully contained x intervals are removed", {
   
 })
 
+test_that("subtractions from x bed_tbl with more chroms than y are captured", {
+  x <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr1",    100,       200,
+    "chr3",    400,       500
+  )
+  
+  y <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr3",    425,       475) 
+  
+  res <- bed_subtract(x, y)
+  expect_true("chr3" %in% res$chrom)
+})
+
+test_that("non-overlapping x intervals are maintained", {
+  x <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr1",    100,       200,
+    "chr3",    400,       500
+  )
+  
+  y <- tibble::frame_data(
+    ~chrom,   ~start,    ~end,
+    "chr3",    425,       475) 
+  
+  res <- bed_subtract(x, y)
+  expect_true("chr1" %in% res$chrom)
+})

--- a/tests/testthat/test_subtract.r
+++ b/tests/testthat/test_subtract.r
@@ -87,7 +87,7 @@ test_that("subtractions from x bed_tbl with more chroms than y are captured", {
   expect_true("chr3" %in% res$chrom)
 })
 
-test_that("non-overlapping x intervals are maintained", {
+test_that("non-overlapping intervals from different chrom are not dropped", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end,
     "chr1",    100,       200,


### PR DESCRIPTION
* Implemented generic `chromLoop` function in `bed_intersect` and `bed_closest` which loops through `x` and `y` bed files and apply's a supplied function with args (e.g. `intersect_group` and `closest_grouped`) to matched `x` and `y` chromosomes. 
* Fixed a bug in `bed_subtract` in which x intervals were dropped if there was not a matching chromosome in `y` bed. 