### PR TITLE
fix duplicate interval reporting and add tests

### DIFF
--- a/inst/include/IntervalTree.h
+++ b/inst/include/IntervalTree.h
@@ -275,9 +275,9 @@ public:
       right->findClosest(start, stop,  closest, min_dist_l, min_dist_r);
     }  
     
-    // handle edge case where remaing intervals 
-    // where stop < intervals.front().start
-    if (!intervals.empty()) {
+    // handle edge case where remaining intervals 
+    // are stop < intervals.front().start
+    if (!intervals.empty()  && (stop < intervals.front().start)) {
       for (typename intervalVector::const_iterator i = intervals.begin(); i != intervals.end(); ++i) {
         const interval& interval = *i;
         if (stop < interval.start) {

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -30,7 +30,6 @@ void closest_grouped(intervalVector& vx, intervalVector& vy,
         indices_y.push_back(ov_it->value) ;
         overlap_sizes.push_back(overlap) ;
         distance_sizes.push_back(0);
-        continue ;
       } else if (ov_it->start > vx_it->stop) {
         indices_x.push_back(vx_it->value) ;
         indices_y.push_back(ov_it->value) ;

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -94,7 +94,7 @@ test_that("check that first right interval at index 0 is not lost", {
 }
 )
 
-test_that("check that strand closest works", {
+test_that("check that strand closest works (strand = TRUE)", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
     "chr1", 100, 200, "a", 10,	"+")
@@ -108,7 +108,7 @@ test_that("check that strand closest works", {
 }
 )
 
-test_that("check that reciprocal strand closest works", {
+test_that("check that reciprocal strand closest works (strand_opp = TRUE) ", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
     "chr1", 100, 200, "a", 10,	"+")
@@ -122,7 +122,7 @@ test_that("check that reciprocal strand closest works", {
 }
 )
 
-test_that("check that stranded distance reporting works", {
+test_that("check that stranded distance reporting works ( distance_type = 'strand') ", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
     "chr1", 100, 200, "a", 10,	"+",
@@ -138,7 +138,7 @@ test_that("check that stranded distance reporting works", {
 }
 )
 
-test_that("check that abs distance reporting works", {
+test_that("check that abs distance reporting works (distance_type = 'abs')", {
   x <- tibble::frame_data(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
     "chr1", 100, 200, "a", 10,	"+",
@@ -171,3 +171,45 @@ test_that("overlapping intervals are removed (overlap = F)", {
   expect_true(res[2, "start.y"] != 19)
 }
 )
+
+test_that("duplicate intervals are not reported", {
+  x <- tibble::frame_data(
+    ~chrom, ~start, ~end,
+    "chr1", 100,    200
+    )
+  
+  y <- tibble::frame_data(
+    ~chrom, ~start, ~end,
+    "chr1", 100,    200,
+    "chr1", 150,    200,
+    "chr1", 550,    580,
+    "chr2", 7000,   8500
+    )
+  res <- bed_closest(x, y)
+  expect_false(any(duplicated(res)))
+}
+)
+
+test_that("all overlapping features are reported", {
+  x <- tibble::frame_data(
+    ~chrom, ~start, ~end,
+    "chr1", 100,    200
+  )
+  
+  y <- tibble::frame_data(
+    ~chrom, ~start, ~end,
+    "chr1", 100,    200,
+    "chr1", 150,    200,
+    "chr1", 50,    100,
+    "chr1", 200,   300
+  )
+  exp <- tibble::frame_data(
+    ~chrom, ~start.x, ~start.y,
+    "chr1", 100,    200
+  )
+  res <- bed_closest(x, y)
+  expect_true(nrow(res) == 4)
+}
+)
+
+


### PR DESCRIPTION
Fix for a minor bug where `bed_closest()` would report duplicate intervals if a certain branch of the code was executed. I also added some tests. 