### PR TITLE
fix bed_flank() errors (closes #59 and #60)

### DIFF
--- a/R/bed_flank.r
+++ b/R/bed_flank.r
@@ -116,10 +116,11 @@ bed_flank <- function(x, genome, both = 0, left = 0,
                          -left_start, -left_end, -right_start, -right_end)
 
   } else {
-    res <- tidyr::gather(res, key, value, left_start, left_end, right_start, right_end)
-    res <- tidyr::separate(res, key, c('pos', 'key'), sep = '_')
-    res <- tidyr::spread(res, key, value)
-    res <- dplyr::select(res, chrom, start, end, everything(), -pos) 
+    res_left <- dplyr::select(res, chrom,  left_start,   left_end, everything(), -right_start, -right_end) 
+    res_right <- dplyr::select(res, chrom,  right_start,   right_end, everything(), -left_start, -left_end)
+    res_left <- dplyr::rename(res_left, start = left_start, end = left_end)
+    res_right<- dplyr::rename(res_right, start = right_start, end = right_end)
+    res <- dplyr::bind_rows(res_left, res_right)
   }   
 
   res <- bound_intervals(res, genome, trim)

--- a/R/valr.r
+++ b/R/valr.r
@@ -24,7 +24,7 @@
 #' @importFrom tibble tribble as_tibble
 #' @importFrom readr read_tsv col_integer col_character col_double
 #' @importFrom stringr str_replace str_split str_c str_length
-#' @importFrom tidyr unnest gather separate spread
+#' @importFrom tidyr unnest
 #' @importFrom purrr by_row
 #' @importFrom lazyeval lazy_dots
 #' @importFrom stats fisher.test

--- a/tests/testthat/test_flank.r
+++ b/tests/testthat/test_flank.r
@@ -29,6 +29,17 @@ test_that("both arg works", {
   expect_equal(nrow(out), 4)
 })
 
+test_that("args with left and right works", {
+  dist_l <- 100
+  dist_r <- 50
+  out <- bed_flank(x, genome, left = dist_l, right = dist_r)
+  expect_equal(nrow(out), 4)
+  # test left side
+  expect_true(x$start[1] - out$start[1] == 100)
+  # test right side
+  expect_true(out$end[3] - x$end[1] == 50)
+})
+  
 test_that("all left and right intervals are reported with both arg", {
   dist <- 100
   out_left <- bed_flank(x, genome, left = dist)
@@ -37,5 +48,87 @@ test_that("all left and right intervals are reported with both arg", {
   out_left_right <- dplyr::bind_rows(out_left, out_right) %>% bed_sort()
   expect_true(all(out_both == out_left_right))
 })
-# test fraction
-# test off chrom
+
+test_that("fraction arg works", {
+  dist <- 0.1
+  out <- bed_flank(x, genome, both = dist, fraction = TRUE)
+  expect_true(nrow(out) == 4)
+  expect_true(all(out$end - out$start == 50))
+})
+
+test_that("strand arg with both works", {
+  dist <- 100
+  out <- bed_flank(x, genome, both = dist, strand = TRUE)
+  out_nostrand <- bed_flank(x, genome, both = dist)
+  expect_true(nrow(out) == 4)
+  expect_true(all(out == out_nostrand))
+})
+
+test_that("strand arg with left works", {
+  dist <- 100
+  out <- bed_flank(x, genome, left = dist, strand = TRUE)
+  expect_true(nrow(out) == 2)
+  plus_in <- dplyr::filter(x, strand == "+")
+  plus_out <- dplyr::filter(out, strand == "+")
+  minus_in <- dplyr::filter(x, strand == "-")
+  minus_out <- dplyr::filter(out, strand == "-")
+  expect_true(plus_in$start > plus_out$start)
+  expect_true(minus_in$start < minus_out$start)
+})
+
+
+test_that("strand arg with right works", {
+  dist <- 100
+  out <- bed_flank(x, genome, right = dist, strand = TRUE)
+  expect_true(nrow(out) == 2)
+  plus_in <- dplyr::filter(x, strand == "+")
+  plus_out <- dplyr::filter(out, strand == "+")
+  minus_in <- dplyr::filter(x, strand == "-")
+  minus_out <- dplyr::filter(out, strand == "-")
+  expect_true(plus_in$start < plus_out$start)
+  expect_true(minus_in$start > minus_out$start)
+})
+
+test_that("strand arg with left and right works", {
+  dist_l <- 100
+  dist_r <- 50
+  out <- bed_flank(x, genome, left = dist_l, right = dist_r, strand = TRUE)
+  expect_true(nrow(out) == 4)
+  # test left side plus strand
+  expect_true(x$start[1] - out$start[1] == 100)
+  # test right side plus strand
+  expect_true(out$end[3] - x$end[1] == 50)
+  # test left side minus strand
+  expect_true(x$start[2] - out$start[2] == 50)
+  # test right side minus strand
+  expect_true(out$end[4] - x$end[2] == 100)
+})
+
+test_that("strand arg with left and right and fraction works", {
+  dist_l <- 0.2
+  dist_r <- 0.1
+  out <- bed_flank(x, genome, left = dist_l, right = dist_r, strand = TRUE, fraction = TRUE)
+  expect_true(nrow(out) == 4)
+  # test left side plus strand
+  expect_true(x$start[1] - out$start[1] == 100)
+  # test right side plus strand
+  expect_true(out$end[3] - x$end[1] == 50)
+  # test left side minus strand
+  expect_true(x$start[2] - out$start[2] == 50)
+  # test right side minus strand
+  expect_true(out$end[4] - x$end[2] == 100)
+})
+
+test_that("intervals are not reported off of chromosomes", {
+    dist <- 600
+    out <- bed_flank(x, genome, left = dist)
+    #test left side
+    expect_true(nrow(out) == 1)
+    expect_true(out$start[1] == 400)
+    #test right side
+    dist <- 3501
+    out <- bed_flank(x, genome, right = dist)
+    expect_true(nrow(out) == 1)
+    expect_true(out$end[1] == 4501)
+  })
+

--- a/tests/testthat/test_flank.r
+++ b/tests/testthat/test_flank.r
@@ -29,5 +29,13 @@ test_that("both arg works", {
   expect_equal(nrow(out), 4)
 })
 
+test_that("all left and right intervals are reported with both arg", {
+  dist <- 100
+  out_left <- bed_flank(x, genome, left = dist)
+  out_right <- bed_flank(x, genome, right = dist)
+  out_both <- bed_flank(x, genome, both = dist)
+  out_left_right <- dplyr::bind_rows(out_left, out_right) %>% bed_sort()
+  expect_true(all(out_both == out_left_right))
+})
 # test fraction
 # test off chrom

--- a/vignettes/valr.Rmd
+++ b/vignettes/valr.Rmd
@@ -213,8 +213,8 @@ bed_merge(x, maxs = max(signal))
 
 `bed_flank` creates new intervals that flank -- but do not contain -- the input intervals.
 
-```{r flank, eval = FALSE}
-bed_flank(x, genome, both = 100)
+```{r flank, eval = TRUE}
+bed_flank(x, genome, both  = 100)
 ```
 
 ### Slop


### PR DESCRIPTION
Instead of using the `tidyr::gather %>% separate %>% spread` approach, I instead created two tables, one with the `left` and another with the `right` flanking intervals, then joined them together. I also added a test to make sure that all of the `left` and `right` intervals are reported. 

I'll work on rewriting this in `Rcpp` to speed it up. 

This also fixes issue #60.  