### PR TITLE
Some progress on bed_shuffle(), passes tests, issue#51

### DIFF
--- a/src/shuffle.cpp
+++ b/src/shuffle.cpp
@@ -173,7 +173,10 @@ DataFrame shuffle_impl(DataFrame df, DataFrame incl, bool within = false,
   IntegerVector df_ends     = df["end"] ;
   
   IntegerVector df_sizes = df_ends - df_starts ;
-
+  
+  // data on incl df
+  CharacterVector incl_chroms = incl["chrom"] ;
+  
   // RNG weighted by chromosome masses
   PDIST chrom_rng = makeChromRNG(incl) ;
   // map of chrom to intervals
@@ -191,7 +194,8 @@ DataFrame shuffle_impl(DataFrame df, DataFrame incl, bool within = false,
   IntegerVector   starts_out(nr) ; 
   IntegerVector   ends_out(nr) ; 
   
-  CharacterVector chrom_names = unique(df_chroms) ;
+  // make master list of chroms found in incl
+  CharacterVector chrom_names = unique(incl_chroms) ;
   
   for (int i = 0; i<nr; ++i) {
    
@@ -199,7 +203,7 @@ DataFrame shuffle_impl(DataFrame df, DataFrame incl, bool within = false,
     if (within) {
       chroms_out[i] = df_chroms[i] ;
     } else {
-      // pick a random chrom index. 
+      // pick a random chrom index.
       int rand_idx = chrom_rng(generator) ;
       chroms_out[i] = chrom_names[rand_idx] ;
     }

--- a/tests/testthat/test_shuffle.r
+++ b/tests/testthat/test_shuffle.r
@@ -73,30 +73,4 @@ test_that('`seed` generates reproducible intervals',{
    expect_identical(res1, res2) 
 })
 
-test_that('`x` intervals not containing all `genome` chroms does not crash', {
-  
-  genome <- tibble::tribble(
-    ~chrom,  ~size,
-    "chr1", 50000000,
-    "chr2", 60000000,
-    "chr3", 80000000
-  ) 
-  
-  
-  x <- tibble::tribble(
-    ~chrom, ~start, ~end,
-    "chr1", 1,    1000,
-    "chr2", 1,    1000,
-    "chr2", 5000, 10000,
-    "chr3", 500,  10000
-  )
-  
-  x_crashes <- tibble::tribble(
-    ~chrom, ~start, ~end,
-    "chr2", 5000, 10000,
-    "chr3", 500,  10000
-  )
-  # crashes 
-  expect_silent(bed_shuffle(x_crashes, genome))
-  
-})
+

--- a/tests/testthat/test_shuffle.r
+++ b/tests/testthat/test_shuffle.r
@@ -72,3 +72,31 @@ test_that('`seed` generates reproducible intervals',{
    res2 <- bed_shuffle(x, genome, seed = seed)
    expect_identical(res1, res2) 
 })
+
+test_that('`x` intervals not containing all `genome` chroms does not crash', {
+  
+  genome <- tibble::tribble(
+    ~chrom,  ~size,
+    "chr1", 50000000,
+    "chr2", 60000000,
+    "chr3", 80000000
+  ) 
+  
+  
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1", 1,    1000,
+    "chr2", 1,    1000,
+    "chr2", 5000, 10000,
+    "chr3", 500,  10000
+  )
+  
+  x_crashes <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr2", 5000, 10000,
+    "chr3", 500,  10000
+  )
+  # crashes 
+  expect_silent(bed_shuffle(x_crashes, genome))
+  
+})


### PR DESCRIPTION
I tracked down one case where I could reproducibly crash RStudio and fixed this specific case. If the `x` intervals do not contain all of the `chroms` found in the `genome`, then it will crash. In this PR, when a random `chrom` is selected, it is selected from a vector of `chroms` in the `genome` rather than the supplied `x` interval `chroms`. This occurs when the default `within = FALSE` is used. 

The current tests now pass (at least the 20+ times i've run them), although there may be additional bugs.  

Here's a reproducible case that will crash when `x_crashes` is run:

```r
library(dplyr)
library(valr)

genome <- tibble::tribble(
  ~chrom,  ~size,
  "chr1", 50000000,
  "chr2", 60000000,
  "chr3", 80000000
) 


x <- tibble::tribble(
  ~chrom, ~start, ~end,
  "chr1", 1,    1000,
  "chr2", 1,    1000,
  "chr2", 5000, 10000,
  "chr3", 500,  10000
)

x_crashes <- tibble::tribble(
  ~chrom, ~start, ~end,
  "chr2", 5000, 10000,
  "chr3", 500,  10000
)

# works
bed_shuffle(x, genome)

# crashes 
bed_shuffle(x_crashes, genome)

```

