### PR TITLE
Additional tests for bed_closest (fixes #79)

### DIFF
--- a/R/bed_closest.r
+++ b/R/bed_closest.r
@@ -67,8 +67,22 @@ bed_closest <- function(x, y, overlap = TRUE,
   distance_type <- match.arg(distance_type, c("genome", "strand", "abs"))
   
   if (strand) {
+    x_pos <- filter(x, strand == "+") 
+    y_pos <- filter(y, strand == "+") 
+    x_neg <- filter(x, strand == "-") 
+    y_neg <- filter(y, strand == "-") 
+    res_pos <- closest_impl(x_pos, y_pos, suffix$x, suffix$y)
+    res_neg <- closest_impl(x_neg, y_neg, suffix$x, suffix$y)
+    res <- bind_rows(res_pos, res_neg)
     res <- filter(res, strand.x == strand.y) 
   } else if (strand_opp) {
+    x_pos <- filter(x, strand == "+") 
+    y_pos <- filter(y, strand == "+") 
+    x_neg <- filter(x, strand == "-") 
+    y_neg <- filter(y, strand == "-") 
+    res_pos <- closest_impl(x_pos, y_neg, suffix$x, suffix$y)
+    res_neg <- closest_impl(x_neg, y_pos, suffix$x, suffix$y)
+    res <- bind_rows(res_pos, res_neg)
     res <- filter(res, strand.x != strand.y) 
   }
   

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -132,7 +132,7 @@ test_that("check that same strand is reported (strand = TRUE", {
 }
 )
 
-test_that("check that different strand is reported (strand = TRUE", {
+test_that("check that different strand is reported (strand_opp = TRUE", {
   x <- tibble::tribble(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
     "chr1",	80,	100,	"q1",	1,	"+"

--- a/tests/testthat/test_closest.r
+++ b/tests/testthat/test_closest.r
@@ -108,6 +108,53 @@ test_that("check that strand closest works (strand = TRUE)", {
 }
 )
 
+test_that("check that same strand is reported (strand = TRUE", {
+  x <- tibble::tribble(
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+    "chr1",	80,	100,	"q1",	1,	"+"
+  )
+    
+  y <- tibble::tribble(
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+    "chr1",	5,	  15,	"d1.1",	1,	"+",
+    "chr1",	20,	  60,	"d1.2",	2,	"-",
+    "chr1",	200,	220,	"d1.3",	3,	"-"
+  ) 
+  
+  pred <- tibble::tribble(
+    ~chrom,   ~start.x,    ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y,    ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",	 80,	100,	"q1",	1,	"+",	5, 	15, 	"d1.1",	1,	"+", 0, -65 
+  )
+  
+  bed_closest(x, y, strand = T)
+  res <- bed_closest(x, y, strand = T)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("check that different strand is reported (strand = TRUE", {
+  x <- tibble::tribble(
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+    "chr1",	80,	100,	"q1",	1,	"+"
+  )
+  
+  y <- tibble::tribble(
+    ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+    "chr1",	5,	  15,	"d1.1",	1,	"+",
+    "chr1",	20,	  60,	"d1.2",	2,	"-",
+    "chr1",	200,	220,	"d1.3",	3,	"-"
+  ) 
+  
+  pred <- tibble::tribble(
+    ~chrom,   ~start.x,    ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y,    ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",	 80,	100,	"q1",	1,	"+",	20, 	60, 	"d1.2",	2,	"-", 0, -20 
+  )
+  
+  res <- bed_closest(x, y, strand_opp = T)
+  expect_true(all(pred == res))
+}
+)
+
 test_that("check that reciprocal strand closest works (strand_opp = TRUE) ", {
   x <- tibble::tribble(
     ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
@@ -211,5 +258,353 @@ test_that("all overlapping features are reported", {
   expect_true(nrow(res) == 4)
 }
 )
+
+test_that("test reporting of first overlapping feature and 
+           overlap = F excludes overlapping intervals", {
+  
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1",	100,	101,
+    "chr1",	200,	201,
+    "chr1",	300,	301,
+    "chr1",	100000,	100010,
+    "chr1",	100020,	100040,
+    "chr2",	1,	10,
+    "chr2",	20,	30)
+
+  y <- tibble::tribble(
+    ~chrom, ~start, ~end,
+    "chr1",	100,	101,
+    "chr1",	150,	201,
+    "chr1",	175,	375
+)
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~start.y, ~end.y, ~.distance,
+    "chr1",	100,	101,  150,  201,  49,
+    "chr1",	200,	201,  100,  101, -99,
+    "chr1",	300,	301,  150,  201, -99,
+    "chr1",	100000,  100010,	175,  375, -99625,
+    "chr1",	100020,  100040,  175,  375, -99645
+)
+  res <- bed_closest(x, y, overlap = F)
+  expect_true(all(pred == res))
+}
+)
+
+### test all distance reporting conditions ###
+
+### tbls to test
+d_q1 <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	80,	100,	"d_q1.1",	5,	"+"
+)
+
+d_q2 <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	80,	100,	"d_q2.1",	5,	"-"
+)
+
+d_d1F <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	40,	60,	"d1F.1",	10,	"+"
+)
+
+d_d1R <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	40,	60,	"d1R.1",	10,	"-"
+)
+
+d_d2F <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	140,	160,	"d2F.1",	10,	"+"
+)
+
+d_d2R <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	140,	160,	"d2R.1",	10,	"-"
+)
+
+test_that("default distance reporting works for forward hit on left, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       -20
+  ) 
+  res <- bed_closest(d_q1, d_d1F)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for forward hit on left, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       -20
+  ) 
+  res <- bed_closest(d_q1, d_d1F, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for forward hit on left, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1F.1",      10,        "+",        0,       20
+  ) 
+  res <- bed_closest(d_q1, d_d1F, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for reverse hit on left, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1R.1",      10,        "-",        0,       -20
+  ) 
+  res <- bed_closest(d_q1, d_d1R)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for reverse hit on left, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      40,    60,  "d1R.1",      10,        "-",        0,       -20
+  ) 
+  res <- bed_closest(d_q1, d_d1R, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for forward hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       -20
+  ) 
+  res <- bed_closest(d_q2, d_d1F)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for forward hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       20
+  ) 
+  res <- bed_closest(d_q2, d_d1F, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for forward hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1F.1",      10,        "+",        0,       20
+  ) 
+  res <- bed_closest(d_q2, d_d1F, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for reverse hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       -20
+  ) 
+  res <- bed_closest(d_q2, d_d1R)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for reverse hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       20
+  ) 
+  res <- bed_closest(d_q2, d_d1R, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for reverse hit on left, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      40,    60,  "d1R.1",      10,        "-",        0,       20
+  ) 
+  res <- bed_closest(d_q2, d_d1R, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+
+test_that("default distance reporting works for forward hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,      40 
+  ) 
+  res <- bed_closest(d_q1, d_d2F)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for forward hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,       40
+  ) 
+  res <- bed_closest(d_q1, d_d2F, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for forward hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2F.1",      10,        "+",        0,       40
+  ) 
+  res <- bed_closest(d_q1, d_d2F, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for reverse hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,      40 
+  ) 
+  res <- bed_closest(d_q1, d_d2R)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for rverse hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,       40
+  ) 
+  res <- bed_closest(d_q1, d_d2R, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for reverse hit on right, forward query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q1.1",       5,        "+",      140,    160,  "d2R.1",      10,        "-",        0,       40
+  ) 
+  res <- bed_closest(d_q1, d_d2R, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for forward hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,      40 
+  ) 
+  res <- bed_closest(d_q2, d_d2F)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for forward hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,       -40
+  ) 
+  res <- bed_closest(d_q2, d_d2F, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for forward hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2F.1",      10,        "+",        0,       40
+  ) 
+  res <- bed_closest(d_q2, d_d2F, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("default distance reporting works for reverse hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,      40 
+  ) 
+  res <- bed_closest(d_q2, d_d2R)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("strand distance reporting works for reverse hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,       -40
+  ) 
+  res <- bed_closest(d_q2, d_d2R, distance_type = "strand")
+  expect_true(all(pred == res))
+}
+)
+
+test_that("abs distance reporting works for reverse hit on right, reverse query", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      80,   100, "d_q2.1",       5,        "-",      140,    160,  "d2R.1",      10,        "-",        0,       40
+  ) 
+  res <- bed_closest(d_q2, d_d2R, distance_type = "abs")
+  expect_true(all(pred == res))
+}
+)
+
+### additional tbls for tests ###
+a2 <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	10,	20,	"a1",	1,	"-"
+)
+
+b2 <- tibble::tribble(
+  ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+  "chr1",	8,	9,	"b1",	1,	"+",
+  "chr1",	21,	22,	"b2",	1, "-"
+)
+
+test_that("Make sure non-overlapping ties are reported ", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      10,   20, "a1",       1,        "-",      21,    22,  "b2",      1,        "-",        0,       1,
+    "chr1",      10,   20, "a1",       1,        "-",      8,    9,  "b1",      1,        "+",        0,       -1
+  ) 
+  res <- bed_closest(a2, b2)
+  expect_true(all(pred == res))
+}
+)
+
+test_that("Make sure non-overlapping ties are reported with strand = T ", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      10,   20, "a1",       1,        "-",      21,    22,  "b2",      1,        "-",        0,       1
+  ) 
+  res <- bed_closest(a2, b2, strand = T)
+  expect_true(all(pred == res))
+}
+)
+
+
+test_that("Make sure non-overlapping ties are reported with strand_opp = T ", {
+  pred <- tibble::tribble(
+    ~chrom, ~start.x, ~end.x, ~name.x, ~score.x, ~strand.x, ~start.y, ~end.y, ~name.y, ~score.y, ~strand.y, ~.overlap, ~.distance,
+    "chr1",      10,   20, "a1",       1,        "-",      8,    9,  "b1",      1,        "+",        0,       -1
+  ) 
+  res <- bed_closest(a2, b2, strand_opp = T)
+  expect_true(all(pred == res))
+}
+)
+
+
+
+
+
+
+
+
 
 


### PR DESCRIPTION
The bug for `bed_closest()` issue #79 was  because the `closest_impl` did not know the `strand` and therefore would not find the closest stranded interval. The fix subsets the supplied x and y tbls by strand and pass these `closest_imp` . It's a slower implementation, but can be fixed also on the `Cxx` side in the future. 

Speed tests:
```r
microbenchmark::microbenchmark(bed_closest(x, y), unit = 's', times = 1)

Unit: seconds
              expr      min       lq     mean   median       uq      max neval
 bed_closest(x, y) 3.993389 3.993389 3.993389 3.993389 3.993389 3.993389     1

microbenchmark::microbenchmark(bed_closest(x, y, strand = T), unit = 's', times = 1)
Unit: seconds
                          expr      min       lq     mean   median       uq      max neval
 bed_closest(x, y, strand = T) 10.72268 10.72268 10.72268 10.72268 10.72268 10.72268     1
```