### PR TITLE
Shuffle bug fixes #81

### DIFF
--- a/R/bed_shuffle.r
+++ b/R/bed_shuffle.r
@@ -54,7 +54,7 @@ bed_shuffle <- function(x, genome, incl = NULL, excl = NULL,
   res <- shuffle_impl(x, incl, within, max_tries, seed)
   res <- as_data_frame(res)
   
-  # by default pass all original x column dat to res
+  # by default pass all original x column data to
   # result (except chrom, start, end) which are shuffled
   # see issue # 81 in github
   

--- a/R/bed_shuffle.r
+++ b/R/bed_shuffle.r
@@ -49,9 +49,14 @@ bed_shuffle <- function(x, genome, incl = NULL, excl = NULL,
 
   if (nrow(incl) == 0 || is.null(incl))
     stop('no intervals to sample from', call. = FALSE)
-
+  
+  #shuffle_impl will drop all columns except chrom, start, and end
   res <- shuffle_impl(x, incl, within, max_tries, seed)
   res <- as_data_frame(res)
- 
-  res 
+  
+  # by default pass all original x column dat to res
+  # result (except chrom, start, end) which are shuffled
+  # see issue # 81 in github
+  
+  res <- bind_cols(res, x[, !colnames(x) %in% colnames(res)])
 }  

--- a/tests/testthat/test_shuffle.r
+++ b/tests/testthat/test_shuffle.r
@@ -100,16 +100,16 @@ test_that('`seed` generates reproducible intervals',{
    expect_identical(res1, res2) 
 })
 
-test_that('chroms intervals are weighted by mass', {
-  x <- bed_random(genome)
-  weighted <- tibble::tribble(
-    ~chrom, ~size,
-    "chr1", 1e4,
-    "chr2", 1e5,
-    "chr3", 1e6
+test_that('all supplied x interval columns are passed to the result', {
+  
+    x <- tibble::tribble(
+      ~chrom,   ~start,    ~end, ~name, ~score, ~strand,
+      "chr1", 80, 100,    "q1",   1,  "+"
     )
-  res <- bed_shuffle(x, genome = weighted) %>%
-    group_by(chrom) %>%
-    summarize(count = n())  
-  expect_identical(res$count, sort(res$count))
+    
+  res <- bed_shuffle(x, genome)
+  expect_true(all(c("strand", "score", "name", "start") %in% colnames(res)))
 })
+
+
+


### PR DESCRIPTION
In the original `bed_shuffle()` implementation only `chrom` `start` and `end` were returned. This fix will pass any original `x` column supplied that is not shuffled (i.e. `score`, `name`, `strand`) to the result. 

Also, we may want to consider if we need to implement a shuffling procedure for `strand` in the future.