### PR TITLE
bed_random() bug fix

### DIFF
--- a/R/bed_random.r
+++ b/R/bed_random.r
@@ -25,7 +25,21 @@
 #' 
 #' @export
 bed_random <- function(genome, length = 1000, n = 1e6, seed = 0) {
-  out <- random_impl(genome, length, n, seed)
+  
+  if (any(length > genome$size)){
+    
+    warn_message <- paste(genome[length > genome$size, ]$chrom, 
+                          "smaller than requested interval lengths, dropping chromosome\n")
+    warning(warn_message)
+    genome <- genome[length < genome$size, ]
+  }
+  
+  if (nrow(genome) > 0){
+    out <- random_impl(genome, length, n, seed)
+  } else {
+    stop("No valid chromosomes found in supplied genome")
+  }
+  
   out <- tibble::as_tibble(out)
   out  
 }

--- a/tests/testthat/test_random.r
+++ b/tests/testthat/test_random.r
@@ -25,7 +25,7 @@ test_that("all ends are less or equal to than chrom size", {
   expect_true(all(res$end <= res$size))
 })
 
-test_that("if length longer than chrom, chrom is dropped", {
+test_that("if length longer than chrom, chrom is dropped (issue #95)", {
   len <- 10000
   suppressWarnings(res <- bed_random(genome, length = len, n = 100))
   expect_false("chr1" %in% res$chrom)

--- a/tests/testthat/test_random.r
+++ b/tests/testthat/test_random.r
@@ -24,3 +24,10 @@ test_that("all ends are less or equal to than chrom size", {
     left_join(genome, by = 'chrom')
   expect_true(all(res$end <= res$size))
 })
+
+test_that("if length longer than chrom, chrom is dropped", {
+  len <- 10000
+  suppressWarnings(res <- bed_random(genome, length = len, n = 100))
+  expect_false("chr1" %in% res$chrom)
+  expect_warning( bed_random(genome, length = len, n = 100))
+})


### PR DESCRIPTION
A few edits to `bed_random()`

* Remove `chroms` from `genome` file if they are smaller than the supplied `length` argument before passing to `random_impl`
* Warn about removed `chroms`
* Do not pass empty `genome` to `random_impl`
* Add test to `test_random.r`

closes #95