### PR TITLE
Fixed map examples 

### DIFF
--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -89,8 +89,8 @@ bed_map <- function(x, y, invert = FALSE,
   
   res <- summarize_(res, .dots = lazyeval::lazy_dots(...))
   res <- ungroup(res)
-  
-  names_no_x <- stringr::str_replace(names(res), suffix$x, '')
+  ## remove x suffix, but don't pattern match with '.' regex
+  names_no_x <- stringr::str_replace(names(res), stringr::fixed(suffix$x), '')
   names(res) <- names_no_x
   
   # find rows of `x` that did not intersect

--- a/R/bed_map.r
+++ b/R/bed_map.r
@@ -58,11 +58,11 @@
 #' bed_map(x, y, vals.unique = values_unique(value))
 #' 
 #' @export
-bed_map <- function(x, y, invert = FALSE,
+bed_map <- function(x, y, ..., invert = FALSE,
                     strand = FALSE, strand_opp = FALSE,
                     suffix = c('.x', '.y'),
-                    min_overlap = 1, ...) {
-
+                    min_overlap = 1) {
+  
   groups_x <- groups(x)
   groups_y <- groups(y)
   


### PR DESCRIPTION
The parameters passed through `...` were overwriting some of the default parameters (invert = FALSE, strand = FALSE, etc.).  I moved the `...` to before the defaults in the function declaration and now all of the examples run. 

Also, there was an issue with the `names_no_x` object, which was pattern matching to a `regex` rather than exactly to the supplied string. For example, the default `x` suffix `.x` would pattern match to a string `max` and convert it to `m` 