### PR TITLE
bed_closest bug duplicate interval reporting closes #105

### DIFF
--- a/inst/include/IntervalTree.h
+++ b/inst/include/IntervalTree.h
@@ -231,11 +231,7 @@ public:
   }
   
   void findClosest(K start, K stop, intervalVector&  closest, 
-                   std::pair<int, intervalVector>& min_dist_l, 
-                   std::pair<int, intervalVector>& min_dist_r) const {
-    
-    int min_node_dist_l = min_dist_l.first ;
-    int min_node_dist_r = min_dist_r.first ;
+                   std::pair<int, intervalVector>& min_dist) const {
     
     if (!intervals.empty() && ! (stop < intervals.front().start)) {
       for (typename intervalVector::const_iterator i = intervals.begin(); i != intervals.end(); ++i) {
@@ -246,73 +242,61 @@ public:
           // finddistance on left
           int ivl_dist_l = interval.start - stop ;
           // if smaller than best min dist found update pair with dist and intervals
-          if (ivl_dist_l < min_node_dist_l) {
-            min_node_dist_l = ivl_dist_l;
-            min_dist_l.first = min_node_dist_l ; 
-            min_dist_l.second.clear() ; 
-            min_dist_l.second.push_back(interval) ;
-          } else if (ivl_dist_l == min_node_dist_l) {
+          if (ivl_dist_l < min_dist.first) {
+            min_dist.first = ivl_dist_l ; 
+            min_dist.second.clear() ; 
+            min_dist.second.push_back(interval) ;
+          } else if (ivl_dist_l == min_dist.first) {
            // if same dist append intervals
-           min_dist_l.second.push_back(interval) ;
+           min_dist.second.push_back(interval) ;
           }
         } else if (start > interval.stop) {
           // find distance on right
           int ivl_dist_r = start - interval.stop ;
           // if smaller than best min dist found update pair with dist and intervals
-          if (ivl_dist_r < min_node_dist_r) {
-            min_node_dist_r = ivl_dist_r;
-            min_dist_r.first = min_node_dist_r ; 
-            min_dist_r.second.clear() ; 
-            min_dist_r.second.push_back(interval) ;
-          } else if (ivl_dist_r == min_node_dist_r) {
+          if (ivl_dist_r < min_dist.first) {
+            min_dist.first = ivl_dist_r ; 
+            min_dist.second.clear() ; 
+            min_dist.second.push_back(interval) ;
+          } else if (ivl_dist_r == min_dist.first) {
             // if same dist append interval
-            min_dist_r.second.push_back(interval) ;
+            min_dist.second.push_back(interval) ;
           }
         }
       }
-        
-        
-    }
-  
-    
-    if (left && start <= center) {
-     left->findClosest(start, stop,  closest, min_dist_l, min_dist_r);
-    }
-    
-    if (right && stop >= center) {
-      right->findClosest(start, stop,  closest, min_dist_l, min_dist_r);
-    }  
-    
-    // handle edge case where remaining intervals 
-    // are stop < intervals.front().start
-    if (!intervals.empty()  && (stop < intervals.front().start)) {
+    }  else if (!intervals.empty()  && (stop < intervals.front().start)) {
       for (typename intervalVector::const_iterator i = intervals.begin(); i != intervals.end(); ++i) {
         const interval& interval = *i;
-        if (stop < interval.start) {
+        if (interval.start > intervals.front().start){
+          continue ;
+        } else {
           // finddistance on left
           int ivl_dist_l = interval.start - stop ;
           // if smaller than best min dist found update pair with dist and intervals
-          if (ivl_dist_l < min_node_dist_l) {
-            min_node_dist_l = ivl_dist_l;
-            min_dist_l.first = min_node_dist_l ; 
-            min_dist_l.second.clear() ; 
-            min_dist_l.second.push_back(interval) ;
-          } else if (ivl_dist_l == min_node_dist_l) {
+          if (ivl_dist_l < min_dist.first) {
+            min_dist.first = ivl_dist_l;
+            min_dist.second.clear() ; 
+            min_dist.second.push_back(interval) ;
+          } else if (ivl_dist_l == min_dist.first) {
             // if same dist append intervals
-            min_dist_l.second.push_back(interval) ;
+            min_dist.second.push_back(interval) ;
           }
         } 
       }
     }
-    // Finally report all of the non-overlapping closest intervals
-
-    if (min_dist_l.first < min_dist_r.first ){
-      closest.insert(closest.end(), min_dist_l.second.begin(), min_dist_l.second.end())  ;
-    } else if (min_dist_l.first == min_dist_r.first) {
-      min_dist_l.second.insert(min_dist_l.second.end(), min_dist_r.second.begin(), min_dist_r.second.end()) ;
-      closest.insert(closest.end(), min_dist_l.second.begin(), min_dist_l.second.end())  ;
-    } else {
-      closest.insert(closest.end(), min_dist_r.second.begin(), min_dist_r.second.end())  ;
+  
+    
+    if (left && start <= center) {
+     left->findClosest(start, stop,  closest, min_dist);
+    }
+    
+    if (right && stop >= center) {
+      right->findClosest(start, stop,  closest, min_dist);
+    }  
+    
+    // Finally report all of the non-overlapping closest intervals, only if at a left_node 
+    if (!(right && left)) {
+      closest.insert(closest.end(), min_dist.second.begin(), min_dist.second.end())  ;
     }
   }
     ~IntervalTree(void) = default;

--- a/src/closest.cpp
+++ b/src/closest.cpp
@@ -5,20 +5,18 @@ void closest_grouped(intervalVector& vx, intervalVector& vy,
                      std::vector<int>& overlap_sizes, std::vector<int>& distance_sizes) {
   
   intervalTree tree_y(vy) ;
-  intervalVector closest ; 
   
-  std::pair<int, intervalVector> min_dist_l, min_dist_r ;
+  std::pair<int, intervalVector> min_dist;
   // initiatialize maximum left and right distances to minimize for closest
   int max_end = std::max(vx.back().stop, vy.back().stop) ;
-  // initialize interval type as placeholder for pair generation
-  intervalVector closest_ivls ;
   
   intervalVector::const_iterator vx_it ;
   for(vx_it = vx.begin(); vx_it != vx.end(); ++vx_it ) {
-
-    min_dist_l = std::make_pair(max_end, closest_ivls) ;
-    min_dist_r = std::make_pair(max_end, closest_ivls) ;
-    tree_y.findClosest(vx_it->start, vx_it->stop, closest, min_dist_l, min_dist_r) ;
+    intervalVector closest ;
+    intervalVector closest_ivls ; 
+    
+    min_dist = std::make_pair(max_end, closest_ivls) ;
+    tree_y.findClosest(vx_it->start, vx_it->stop, closest, min_dist) ;
     
     intervalVector::const_iterator ov_it ;
     for(ov_it = closest.begin(); ov_it != closest.end(); ++ov_it ) {


### PR DESCRIPTION
The bug was caused by the recursive fxn `findClosest` which would report back intervals for each function call throughout the recursion. I changed the logic so that it would only report intervals back once a `terminal node` (aka `leaf node`) of the interval tree has been reached. I also clarified some variables and added two additional tests .