### PR TITLE
bed_merge() bug not allowing summaries issue#132

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -11,11 +11,12 @@ valr_example <- function(path) {
   system.file("extdata", path, package = 'valr', mustWork = TRUE)
 }
 
-#' reformat bed tbl to match another tbl
+#' reformat tbl column ordering based upon another tbl
 #' 
-#' \code{format_bed} returns a tbl whose columns are ordered by another tbl.
-#' Columns not found in \code{y} tbl are dropped from \code{x}. \code{y} columns
-#'  not found in \code{x} are added to \code{x} and populated with a dummy entry \code{"."}
+#' \code{format_bed} returns a tbl whose columns are ordered by another tbl. 
+#' The \code{x} tbl columns are reordered based on the \code{y} columns ordering.
+#' If there are \code{x} columns that do not exist in \code{y} they are moved to the last column. 
+#'
 #'  
 #' @param x tbl of intervals
 #' @param y tbl of intervals

--- a/R/utils.r
+++ b/R/utils.r
@@ -39,15 +39,9 @@ format_bed <- function(x, y) {
   names_x <- names(x)
   names_y <- names(y)
   
-  if (any(!names_y %in% names_x)){
-    cols_to_add <- setdiff(names_y, names_x)
-    n <- ncol(x)
-    for (i in seq_along(cols_to_add)){
-      x[n + i] <- "."
-      colnames(x)[n + i] <- cols_to_add[i]
-    }
-  }
-  x <- select(x, one_of(names_y))
+  names_x <- names_x[order(match(names_x,names_y))]
+  
+  x <- select(x, one_of(names_x))
   x
 }
 

--- a/tests/testthat/test_merge.r
+++ b/tests/testthat/test_merge.r
@@ -116,6 +116,25 @@ test_that("summaries can be computed issue #132",{
   )
   
   res <- bed_merge(x, .value = sum(value))
-  expect_equal(res$.value != ".")
-  expect_true(all(res$.value = c(1, 5, 4, 18)))
+  expect_true(all(res$.value != "."))
+  expect_true(all(res$.value == c(1, 5, 4, 18)))
+})
+
+test_that("multiple summaries can be computed issue #132",{
+  
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end, ~value, ~strand,
+    "chr1", 1,      50,   1,      '+',
+    "chr1", 100,    200,  2,      '+',
+    "chr1", 150,    250,  3,      '-',
+    "chr2", 1,      25,   4,      '+',
+    "chr2", 200,    400,  5,      '-',
+    "chr2", 400,    500,  6,      '+',
+    "chr2", 450,    550,  7,      '+'
+  )
+  
+  res <- bed_merge(x, .value = sum(value), .min = min(value))
+  expect_true(all(res$.value != "."))
+  expect_true(all(res$.value == c(1, 5, 4, 18)))
+  expect_true(all(res$.min == c(1, 2, 4, 5)))
 })

--- a/tests/testthat/test_merge.r
+++ b/tests/testthat/test_merge.r
@@ -102,3 +102,20 @@ test_that("intervals can be merged by strand",{
   expect_equal(nrow(res), 2)
 })
 
+test_that("summaries can be computed issue #132",{
+  
+  x <- tibble::tribble(
+    ~chrom, ~start, ~end, ~value, ~strand,
+    "chr1", 1,      50,   1,      '+',
+    "chr1", 100,    200,  2,      '+',
+    "chr1", 150,    250,  3,      '-',
+    "chr2", 1,      25,   4,      '+',
+    "chr2", 200,    400,  5,      '-',
+    "chr2", 400,    500,  6,      '+',
+    "chr2", 450,    550,  7,      '+'
+  )
+  
+  res <- bed_merge(x, .value = sum(value))
+  expect_equal(res$.value != ".")
+  expect_true(all(res$.value = c(1, 5, 4, 18)))
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -40,7 +40,11 @@ y <- tibble::frame_data(
   "chr1",    100,       150,  2.4
 )
 
-test_that("columns are reordered and dropped if not in y tbl, format_bed()", {
+test_that("x columns are reordered based on y, format_bed()", {
   res <- format_bed(x, y)
-  expect_true(all(colnames(y) == colnames(res)))
+  
+  pred <- intersect(colnames(y), colnames(res))
+  n <- length(pred)
+
+  expect_true(all(colnames(res[1:n]) == pred[1:n]))
 })


### PR DESCRIPTION
I changed `format_bed()` to only reorder columns rather than drop or replace with a dummy variable and added some tests for the bug. 

closes #132