### PR TITLE
bed_absdist() equation and bed_shuffle() reporting 137 138

### DIFF
--- a/R/bed_absdist.r
+++ b/R/bed_absdist.r
@@ -11,8 +11,7 @@
 #'   the chromosome for a supplied  \code{x} interval has no matching  \code{y}
 #'   chromosome, the \code{absdist} will be reported as an \code{NA}.
 #'   
-#'   \deqn{ d_i(x,y) = min_{\substack{k}}(|q_i - r_k|)\frac{R}{Length\ of\
-#'   chromsome}}
+#'   \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromsome}}
 #'   
 #'   By default both absolute and scaled distances are reported as \code{.absdist} and
 #'   \code{.absdist_scaled} respectively.

--- a/R/bed_absdist.r
+++ b/R/bed_absdist.r
@@ -11,7 +11,7 @@
 #'   the chromosome for a supplied  \code{x} interval has no matching  \code{y}
 #'   chromosome, the \code{absdist} will be reported as an \code{NA}.
 #'   
-#'   \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromsome}}
+#'   \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromosome}}
 #'   
 #'   By default both absolute and scaled distances are reported as \code{.absdist} and
 #'   \code{.absdist_scaled} respectively.

--- a/R/bed_shuffle.r
+++ b/R/bed_shuffle.r
@@ -59,4 +59,6 @@ bed_shuffle <- function(x, genome, incl = NULL, excl = NULL,
   # see issue # 81 in github
   
   res <- bind_cols(res, x[, !colnames(x) %in% colnames(res)])
+  
+  res
 }  

--- a/man/bed_absdist.Rd
+++ b/man/bed_absdist.Rd
@@ -32,8 +32,7 @@ Compute absolute distances between intervals.
   the chromosome for a supplied  \code{x} interval has no matching  \code{y}
   chromosome, the \code{absdist} will be reported as an \code{NA}.
   
-  \deqn{ d_i(x,y) = min_{\substack{k}}(|q_i - r_k|)\frac{R}{Length\ of\
-  chromsome}}
+  \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromsome}}
   
   By default both absolute and scaled distances are reported as \code{.absdist} and
   \code{.absdist_scaled} respectively.

--- a/man/bed_absdist.Rd
+++ b/man/bed_absdist.Rd
@@ -32,7 +32,7 @@ Compute absolute distances between intervals.
   the chromosome for a supplied  \code{x} interval has no matching  \code{y}
   chromosome, the \code{absdist} will be reported as an \code{NA}.
   
-  \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromsome}}
+  \deqn{d_i(x,y) = min_k(|q_i - r_k|)\frac{R}{Length\ of\ chromosome}}
   
   By default both absolute and scaled distances are reported as \code{.absdist} and
   \code{.absdist_scaled} respectively.


### PR DESCRIPTION
`bed_shuffle()` wasn't returning the result by default. 

The `bed_absdist()` equation was simplified, which has now has no problems on `win_builder`
 
win_builder output:
https://gist.github.com/kriemo/27bd382a126b7de259624e1b84d8aa91

closes #137 and #138