### PR TITLE
fix indexing error that was causing a memory-access error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Major changes
 
 ## Minor changes
- 
+- fixed memory-access error in absdist.cpp
 - fixed vignette entry names
 
 # valr 0.1.0

--- a/src/absdist.cpp
+++ b/src/absdist.cpp
@@ -26,12 +26,19 @@ void absdist_grouped(intervalVector& vx, intervalVector& vy,
 
     // set up indexes for closest element, handling edge cases at start and end of x ivl vector
     if (low_idx == 0) {
-      // just search for closest higher ivl, but do it twice to prevent indexing errors
-      upper_idx = low_idx + 1 ;
+      // no need to continue return absdist
+      int dist = ref_midpoints[low_idx] ;
+      int absdist = abs(dist - midpoint) ;
+      
+      rel_distances.push_back(absdist) ;
+      indices_x.push_back(vx_it.value) ;
+      continue ; 
+      
     } else if (low_idx == ref_midpoints.size()) {
       // just search for closest lower ivl
       low_idx = low_idx - 1;
       upper_idx = low_idx;
+      
     } else {
       // search either
       // get index below and above


### PR DESCRIPTION
When `valgrind` is run on the test suite there is a memory access error in `absdist.cpp`:

```bash
R -d "valgrind --tool=memcheck --dsymutil=yes" --no-readline --vanilla < testthat.R
```
The relevant error
```r
> test_check("valr")
  ==12828== Invalid read of size 4
  ==12828==    at 0x1143352BD: absdist_grouped(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x11433609C: void PairedGroupApply<void (&)(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&), std::__1::reference_wrapper<std::__1::vector<int, std::__1::allocator<int> > >, std::__1::reference_wrapper<std::__1::vector<float, std::__1::allocator<float> > > >(Rcpp::GroupedDataFrame const&, Rcpp::GroupedDataFrame const&, void (&)(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&), std::__1::reference_wrapper<std::__1::vector<int, std::__1::allocator<int> > >&&, std::__1::reference_wrapper<std::__1::vector<float, std::__1::allocator<float> > >&&) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x114335426: absdist_impl(Rcpp::GroupedDataFrame, Rcpp::GroupedDataFrame) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x11432D545: valr_absdist_impl (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x100088666: do_dotcall (dotcode.c:1251)
  ==12828==    by 0x1000B5D6B: Rf_eval (eval.c:713)
  ==12828==    by 0x10010DD42: do_begin (eval.c:1806)
  ==12828==    by 0x1000B5F9D: Rf_eval (eval.c:685)
  ==12828==    by 0x10010AA44: Rf_applyClosure (eval.c:1134)
  ==12828==    by 0x1000B5EA6: Rf_eval (eval.c:732)
  ==12828==    by 0x10010E8B1: do_set (eval.c:2196)
  ==12828==    by 0x1000B5F9D: Rf_eval (eval.c:685)
  ==12828==  Address 0x1057c4d14 is 0 bytes after a block of size 4 alloc'd
  ==12828==    at 0x100008EBB: malloc (in /usr/local/Cellar/valgrind/3.11.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
  ==12828==    by 0x101B5B1AD: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
  ==12828==    by 0x114347AF1: void std::__1::vector<float, std::__1::allocator<float> >::__push_back_slow_path<float>(float&&) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x1143351BB: absdist_grouped(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x11433609C: void PairedGroupApply<void (&)(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&), std::__1::reference_wrapper<std::__1::vector<int, std::__1::allocator<int> > >, std::__1::reference_wrapper<std::__1::vector<float, std::__1::allocator<float> > > >(Rcpp::GroupedDataFrame const&, Rcpp::GroupedDataFrame const&, void (&)(std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<Interval<int, int>, std::__1::allocator<Interval<int, int> > >&, std::__1::vector<int, std::__1::allocator<int> >&, std::__1::vector<float, std::__1::allocator<float> >&), std::__1::reference_wrapper<std::__1::vector<int, std::__1::allocator<int> > >&&, std::__1::reference_wrapper<std::__1::vector<float, std::__1::allocator<float> > >&&) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x114335426: absdist_impl(Rcpp::GroupedDataFrame, Rcpp::GroupedDataFrame) (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x11432D545: valr_absdist_impl (in /Library/Frameworks/R.framework/Versions/3.3/Resources/library/valr/libs/valr.so)
  ==12828==    by 0x100088666: do_dotcall (dotcode.c:1251)
  ==12828==    by 0x1000B5D6B: Rf_eval (eval.c:713)
  ==12828==    by 0x10010DD42: do_begin (eval.c:1806)
  ==12828==    by 0x1000B5F9D: Rf_eval (eval.c:685)
  ==12828==    by 0x10010AA44: Rf_applyClosure (eval.c:1134)
  ==12828==
  testthat results ================================================================
  OK: 269 SKIPPED: 3 FAILED: 0
```
The `bed_absdist()` test that triggers this error is here:
https://github.com/jayhesselberth/valr/blob/master/tests/testthat/test_absdist.r#L94

which is a condition where there is only 1 `y` intervals to test for `absdist`.

This PR changes the logic in `absdist.cpp` so that this condition is handled without accidentally accessing non allocated memory and now passes `valgrind`.
```r
> test_check("valr")
  testthat results ================================================================
  OK: 269 SKIPPED: 3 FAILED: 0
>
```